### PR TITLE
Add Enterprise Support

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,3 +41,4 @@ jobs:
         HL_CLIENT_SECRET: ${{ secrets.HL_CLIENT_SECRET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AZURE_BLOB_SAS_KEY: ${{ secrets.SAS_KEY }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For more information about GitHub Actions:
 
 `model_path` (required): Path to the model(s), can either be a path to a single model in the repo, a folder containing the model(s) in the repo or a path on s3 to the model.
 
-`api_url`: URL to the HiddenLayer API if you're using the OEM/self hosted version. Defaults to `https://api.hiddenlayer.ai`.
+`api_url`: URL to the HiddenLayer API if you're using the OEM/self hosted version. Defaults to `https://api.us.hiddenlayer.ai`.
 
 > Note: For customers using the Enterprise Self Hosted Model Scanner, please ensure your Github Action runners can make network requests to the Model Scanner API.
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ For more information about GitHub Actions:
 
 `api_url`: URL to the HiddenLayer API if you're using the OEM/self hosted version. Defaults to `https://api.hiddenlayer.ai`.
 
+> Note: For customers using the Enterprise Self Hosted Model Scanner, please ensure your Github Action runners can make network requests to the Model Scanner API.
+
 ## Environment Variables
 
-`HL_CLIENT_ID` (required): Your HiddenLayer API Client ID.
+`HL_CLIENT_ID` (**required for SaaS only**): Your HiddenLayer API Client ID.
 
-`HL_CLIENT_SECRET` (required): Your HiddenLayer API Client Secret.
+`HL_CLIENT_SECRET` (**required for SaaS only**): Your HiddenLayer API Client Secret.
 
 `AWS_ACCESS_KEY_ID`: Required when scanning a model on S3 if not using self hosted runners with access to S3.
 
@@ -40,7 +42,7 @@ For more information about GitHub Actions:
 
 ## Example Usage
 
-### Scanning a model
+### Scanning a model using the SaaS Platform
 
 ```yaml
 jobs:
@@ -57,6 +59,23 @@ jobs:
         env:
           HL_CLIENT_ID: ${{ secrets.HL_CLIENT_ID }}
           HL_CLIENT_SECRET: ${{ secrets.HL_CLIENT_SECRET }}
+```
+
+### Scanning a model using the Enterprise Self Hosted Model Scanner
+
+```yaml
+jobs:
+  scan_model:
+    runs-on: ubuntu-latest
+    name: Scan a model
+    steps:
+      - uses: actions/checkout@v3
+      - name: Scan model
+        id: scan_model
+        uses: hiddenlayerai/hiddenlayer-model-scan-github-action@latest
+        with:
+          model_path: ./models/pytorch_model.bin
+          api_url: "https://your.enterprise.url"
 ```
 
 ### Scanning a model folder

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   api_url:
     description: 'URL of the HiddenLayer API'
     required: false
-    default: 'https://api.hiddenlayer.ai'
+    default: 'https://api.us.hiddenlayer.ai'
 outputs:
   detection_results:
     description: 'Markdown table of detection results.'

--- a/model_scan.py
+++ b/model_scan.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import markdown
 
 
-def main(model_path: str, api_url: str = "https://api.hiddenlayer.ai"):
+def main(model_path: str, api_url: str = "https://api.us.hiddenlayer.ai"):
     """
     Scans a model using the HiddenLayer API.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-hiddenlayer-sdk[aws,azure] @ git+https://github.com/hiddenlayerai/hiddenlayer-sdk-python.git@c3a0177
+hiddenlayer-sdk[aws,azure] @ git+https://github.com/hiddenlayerai/hiddenlayer-sdk-python.git@920a11286f4811f4f10f375aa0af1bb814dbe70d

--- a/tests/test_model_scan.py
+++ b/tests/test_model_scan.py
@@ -2,29 +2,41 @@ import pytest
 
 import model_scan
 
+params = [
+    ("https://api.hiddenlayer.ai"),
+    pytest.param(
+        "http://localhost:8000",
+    ),  # marks=pytest.mark.xfail)
+]
 
-def test_model_scan_local_file():
+
+@pytest.mark.parametrize("host", params)
+def test_model_scan_local_file(host):
     """Test that scanning a model doesn't break."""
-    model_scan.main(model_path="tests/models/example_model.xgb")
+    model_scan.main(model_path="tests/models/example_model.xgb", api_url=host)
 
 
-def test_model_scan_s3():
+@pytest.mark.parametrize("host", params)
+def test_model_scan_s3(host):
     """Test scanning a malicious model breaks."""
 
     with pytest.raises(SystemExit) as e:
         model_scan.main(
-            model_path="s3://hl-oss-integration-tests/example_models/malicious_torch.bin"
+            model_path="s3://hl-oss-integration-tests/example_models/malicious_torch.bin",
+            api_url=host,
         )
 
     assert e.value.code == 1
 
 
-def test_model_scan_azure():
+@pytest.mark.parametrize("host", params)
+def test_model_scan_azure(host):
     """Test scanning a malicious model on azure."""
 
     with pytest.raises(SystemExit) as e:
         model_scan.main(
-            model_path="https://dsdemomodelsstorage.blob.core.windows.net/azureml/malicious_model.bin"
+            model_path="https://dsdemomodelsstorage.blob.core.windows.net/azureml/malicious_model.bin",
+            api_url=host,
         )
 
     assert e.value.code == 1

--- a/tests/test_model_scan.py
+++ b/tests/test_model_scan.py
@@ -3,7 +3,7 @@ import pytest
 import model_scan
 
 params = [
-    ("https://api.hiddenlayer.ai"),
+    ("https://api.us.hiddenlayer.ai"),
     pytest.param("http://localhost:8000", marks=pytest.mark.xfail),
 ]
 

--- a/tests/test_model_scan.py
+++ b/tests/test_model_scan.py
@@ -4,9 +4,7 @@ import model_scan
 
 params = [
     ("https://api.hiddenlayer.ai"),
-    pytest.param(
-        "http://localhost:8000",
-    ),  # marks=pytest.mark.xfail)
+    pytest.param("http://localhost:8000", marks=pytest.mark.xfail),
 ]
 
 


### PR DESCRIPTION
## Describe your changes

- Update hiddenlayer sdk to bring in enterprise support by passing in a non SaaS url
- Updated README to note that the GH runner must be able to connect to the Modscan API
- Add enterprise tests
