### PR TITLE
Fix issue with SARIF reports getting overwritten

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ For more information about GitHub Actions:
 
 `sarif_file`: Output file to write the scan results to in the SARIF format.
 
+`run_id`: Run id for the current run of the model scanner. Defaults to `YYYYMMDDTHHMMSS`
+
 > Note: For customers using the Enterprise Self Hosted Model Scanner, please ensure your Github Action runners can make network requests to the Model Scanner API.
 
 ## Environment Variables

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: Writes detection output in the SARIF format to a json file.
     required: false
     default: null
+  run_id:
+    description: Run ID
+    required: false
+    default: null
 outputs:
   detection_results:
     description: 'Markdown table of detection results.'
@@ -34,4 +38,5 @@ runs:
     - ${{ inputs.api_url }}
     - ${{ inputs.output_file }}
     - ${{ inputs.sarif_file }}
+    - ${{ inputs.run_id }}
     - ${{ inputs.fail_on_detection == 'true' && '--fail-on-detection' || null }}

--- a/model_scan.py
+++ b/model_scan.py
@@ -19,6 +19,7 @@ def main(
     fail_on_detection: bool = True,
     output_file: Optional[str] = None,
     sarif_file: Optional[str] = None,
+    run_id: Optional[str] = None,
 ):
     """
     Scans a model using the HiddenLayer API.
@@ -131,7 +132,7 @@ def main(
             json.dump(json_output, f, indent=4)
 
     if sarif_file:
-        sarif_output = sarif.SarifV2Output.from_scan_results(all_scan_results)
+        sarif_output = sarif.SarifV2Output.from_scan_results(all_scan_results, run_id)
         with open(sarif_file, "w") as f:
             json.dump(sarif_output.model_dump(by_alias=True), f, indent=4)
 
@@ -146,6 +147,7 @@ if __name__ == "__main__":
     parser.add_argument("api_url", type=str)
     parser.add_argument("output_file", type=str)
     parser.add_argument("sarif_file", type=str)
+    parser.add_argument("run_id", type=str)
     parser.add_argument("--fail-on-detection", action="store_true", required=False)
 
     # Since this is running from a Github action, if there are 5 total args to the program
@@ -163,4 +165,5 @@ if __name__ == "__main__":
         args[0].fail_on_detection,
         args[0].output_file,
         args[0].sarif_file,
+        args[0].run_id,
     )

--- a/tests/test_model_scan.py
+++ b/tests/test_model_scan.py
@@ -145,7 +145,7 @@ def test_sarif_output_no_detections(host):
         "runs": [
             {
                 "tool": {
-                    "driver": {"name": "HiddenLayer Model Scanner", "version": "24.7.0"}
+                    "driver": {"name": "HiddenLayer Model Scanner", "version": "24.8.0"}
                 },
                 "results": [],
             }
@@ -164,6 +164,9 @@ def test_sarif_output_no_detections(host):
     with open(output_path, "r") as f:
         output = json.load(f)
 
+    # Dynamic field that must exist but doesn't need to be validated
+    del output["runs"][0]["automationDetails"]
+
     os.remove(output_path)
 
     TestCase().assertDictEqual(expected_output, output)
@@ -178,7 +181,7 @@ def test_sarif_output_detections(host):
         "runs": [
             {
                 "tool": {
-                    "driver": {"name": "HiddenLayer Model Scanner", "version": "24.7.0"}
+                    "driver": {"name": "HiddenLayer Model Scanner", "version": "24.8.0"}
                 },
                 "results": [
                     {
@@ -219,6 +222,9 @@ def test_sarif_output_detections(host):
 
     with open(output_path, "r") as f:
         output = json.load(f)
+
+    # Dynamic field that must exist but doesn't need to be validated
+    del output["runs"][0]["automationDetails"]
 
     os.remove(output_path)
 


### PR DESCRIPTION
## Describe your changes

- Add an optional `run_id` field that captures the run name each time a SARIF report is generated. Previously you wouldn't be able to tell how many times an alert was generated and from which run
