### PR TITLE
Update to latest HL Python SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-hiddenlayer-sdk[aws,azure,hf]==2.0.4
+hiddenlayer-sdk[aws,azure,hf]==2.0.5
 pydantic>=2.0.0


### PR DESCRIPTION
## Describe your changes

Update to 2.0.5 of HL Python SDK. Removes requirement that modscan reports have `risk` field.

## Issue ticket number and link
