### PR TITLE
switch tests to use test-models due to change in HF

### DIFF
--- a/.github/workflows/weekly-action-test.yml
+++ b/.github/workflows/weekly-action-test.yml
@@ -40,7 +40,7 @@ jobs:
         id: community_scan_huggingface
         uses: ./ # Testing the action from this repository
         with:
-          model_path: https://HuggingFace.co/ScanMe/Models
+          model_path: https://HuggingFace.co/ScanMe/test-models
           fail_on_detection: false
           output_file: output.json
           sarif_file: output.sarif

--- a/tests/test_model_scan.py
+++ b/tests/test_model_scan.py
@@ -198,7 +198,7 @@ def test_community_scan(host):
     """Test community Scan with HuggingFace ScanMe repo"""
 
     model_scan.main(
-        model_path="ScanMe/Models",
+        model_path="ScanMe/test-models",
         api_url=host,
         model_name="GHA Community Scan Test",
         community_scan="HUGGING_FACE",


### PR DESCRIPTION
Based on the recent HuggingFace changes, this PR:
* updates the location of the model for community scan to ScanMe/test-models
